### PR TITLE
feat: Replace 'normal' enemy with new 'fast' type

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -107,12 +107,14 @@ export const config = {
         eliteSizeMultiplier: 1.3,
         healthIncreasePerLevel: 0.3,
         types: {
-            normal: {
+            fast: {
+                name: "Rápido",
                 chance: 0.6,
-                speed: 2.0,
+                speed: 3.5, // Faster than the old hunter
                 behavior: 'wander',
-                face: [">:(", "X_X", ">_<", ":O"],
-                color: '#FF5555'
+                face: ["😠", "😡", "😤"],
+                color: '#FFDD00', // Yellow to signify speed
+                healthMultiplier: 0.8 // 80% of base health
             },
             hunter: {
                 chance: 0.3,

--- a/js/enemy.js
+++ b/js/enemy.js
@@ -25,7 +25,7 @@ export function spawnEnemy(currentEnemies, typeKey = null) {
             }
         }
         if (!typeKey) {
-            typeKey = 'normal';
+            typeKey = 'fast';
         }
 
         const type = config.enemySystem.types[typeKey];
@@ -35,9 +35,10 @@ export function spawnEnemy(currentEnemies, typeKey = null) {
         }
 
         const isElite = typeKey === 'boss' || typeKey === 'finalBoss' || Math.random() < 0.1;
-        const healthMultiplier = type.health || (config.enemySystem.baseHealth + (config.wave.number * config.enemySystem.healthIncreasePerLevel));
-
-        const health = type.health || (config.enemySystem.baseHealth + (config.wave.number * config.enemySystem.healthIncreasePerLevel));
+        let health = type.health || (config.enemySystem.baseHealth + (config.wave.number * config.enemySystem.healthIncreasePerLevel));
+        if (type.healthMultiplier) {
+            health *= type.healthMultiplier;
+        }
 
         const enemy = {
             x: Math.random() * window.innerWidth,


### PR DESCRIPTION
This commit replaces the basic 'normal' enemy with the new 'fast' type, as requested by the user.

- The `normal` enemy definition in `js/config.js` has been renamed to `fast`.
- The `fast` enemy has significantly increased speed and slightly reduced health (via a new `healthMultiplier` property).
- The `spawnEnemy` function in `js/enemy.js` has been updated to recognize and apply the `healthMultiplier`, making the system more flexible for future enemy variations.