### PR TITLE
fix: Unlock all audio on first user interaction

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -488,6 +488,16 @@ function setupControls() {
     const player = config.players[0];
     const menu = document.getElementById('menu');
 
+    const handleFirstInteraction = () => {
+        sound.unlockAudio();
+        // Remove the listeners after the first interaction
+        canvas.removeEventListener('mousemove', handleFirstInteraction);
+        window.removeEventListener('keydown', handleFirstInteraction);
+    };
+
+    canvas.addEventListener('mousemove', handleFirstInteraction);
+    window.addEventListener('keydown', handleFirstInteraction);
+
     canvas.addEventListener('mousemove', (e) => { player.x = e.clientX; player.y = e.clientY; });
 
     window.addEventListener('keydown', (e) => {

--- a/js/utils.js
+++ b/js/utils.js
@@ -58,3 +58,13 @@ export function initSoundSystem() {
         config.soundEnabled = savedSoundPref === 'true';
     }
 }
+
+let audioUnlocked = false;
+export function unlockAudio() {
+    if (audioUnlocked) return;
+    audioUnlocked = true;
+
+    Object.values(config.soundEffects).forEach(sound => {
+        sound.play().then(() => sound.pause()).catch(() => {});
+    });
+}


### PR DESCRIPTION
This commit fixes a bug where sound effects (specifically for projectile explosions) would not play until after the first boss fight had concluded.

This is caused by browser auto-play policies that prevent audio from being played programmatically without a prior user interaction.

The fix implements a standard audio unlocking pattern:
- A new `unlockAudio()` function is added to `js/utils.js`. It iterates through all loaded sound effects, plays them, and immediately pauses them. This "primes" them for future playback.
- This function is triggered once on the very first user interaction (`mousemove` or `keydown`), ensuring all sounds are available to be played programmatically for the rest of the session.