### PR TITLE
fix: Rebalance enemy spawn chances to fix spawning bug

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -109,7 +109,7 @@ export const config = {
         types: {
             fast: {
                 name: "Rápido",
-                chance: 0.6,
+                chance: 0.55,
                 speed: 3.5, // Faster than the old hunter
                 behavior: 'wander',
                 face: ["😠", "😡", "😤"],
@@ -117,7 +117,7 @@ export const config = {
                 healthMultiplier: 0.8 // 80% of base health
             },
             hunter: {
-                chance: 0.3,
+                chance: 0.25,
                 speed: 2.0, // A bit slower so they don't just rush in
                 behavior: 'huntAndShoot', // New behavior
                 face: ["🎯", "🔫", "💥"], // New face
@@ -128,7 +128,7 @@ export const config = {
             },
             cosmic: {
                 name: "Cósmico",
-                chance: 0.1,
+                chance: 0.10,
                 speed: 4.5,
                 behavior: 'crossScreen',
                 face: ["☄️", "🌠"],
@@ -138,7 +138,7 @@ export const config = {
             },
             shooter: {
                 name: "Atirador",
-                chance: 0.05, // Starts low
+                chance: 0.10,
                 speed: 0,
                 behavior: 'static',
                 face: ["🛰️", "📡"],

--- a/js/enemy.js
+++ b/js/enemy.js
@@ -17,12 +17,14 @@ export function spawnEnemy(currentEnemies, typeKey = null) {
             for (const [key, type] of Object.entries(config.enemySystem.types)) {
                 if (type.chance > 0) {
                     let currentChance = type.chance;
-                    // Special progressive spawning for shooters
+                    // Special progressive spawning for shooters (temporarily disabled to fix spawn bug)
+                    /*
                     if (key === 'shooter') {
                         // The chance increases by 1% each wave, capped at a max of, say, 40%
                         currentChance += (config.wave.number * 0.01);
                         currentChance = Math.min(currentChance, 0.40);
                     }
+                    */
                     cumulativeChance += currentChance;
                     if (random <= cumulativeChance) {
                         typeKey = key;


### PR DESCRIPTION
This commit fixes a critical bug where some enemy types (Cosmic, Shooter) would never spawn.

The root cause was that the sum of the `chance` properties for all randomly spawning enemies exceeded 1.0, breaking the weighted random selection algorithm.

This patch rebalances the spawn chances in `js/config.js` so that they correctly sum to 1.0. It also temporarily comments out the progressive spawning logic for the 'Shooter' to ensure the static, balanced chances are used, guaranteeing all enemy types can now appear in the game.