### PR TITLE
Fix: Corrigir regressão que impedia o jogo de carregar

### DIFF
--- a/js/enemy.js
+++ b/js/enemy.js
@@ -134,7 +134,7 @@ export function spawnEnemy(config, currentEnemies, typeKey = null) {
  * @param {Array} projectiles - O array de projéteis.
  * @returns {object} Um objeto contendo o XP ganho e os novos arrays de entidades.
  */
-export function updateEnemies(enemies, player, deltaTime, particles, projectiles) {
+export function updateEnemies(config, enemies, player, deltaTime, particles, projectiles) {
     let xpFromDefeatedEnemies = 0;
     let remainingEnemies = [];
     let particlesFromExplosions = particles;

--- a/js/game.js
+++ b/js/game.js
@@ -336,7 +336,7 @@ function updatePhysics(deltaTime) {
     state.setExplosions(explosion.updateExplosions(state.explosions));
 
     if (state.enemies.length > 0) {
-        const enemyUpdate = enemy.updateEnemies(state.enemies, player, deltaTime, state.particles, state.projectiles);
+        const enemyUpdate = enemy.updateEnemies(config, state.enemies, player, deltaTime, state.particles, state.projectiles);
         state.setEnemies(enemyUpdate.newEnemies);
         state.setParticles(enemyUpdate.newParticles);
         state.setProjectiles(enemyUpdate.newProjectiles);


### PR DESCRIPTION
Esta correção resolve uma regressão crítica introduzida durante a tradução dos comentários, que impedia o jogo de carregar.

O problema foi causado pela remoção acidental da importação do objeto `config` no arquivo `js/enemy.js`, enquanto a função `updateEnemies` ainda dependia dele. Isso resultava em um `ReferenceError` que quebrava a execução do script.

A correção envolve duas etapas para garantir a robustez e consistência do código:
1. A função `updateEnemies` em `js/enemy.js` foi refatorada para aceitar `config` como um parâmetro explícito, em vez de depender de uma importação global.
2. A chamada a `updateEnemies` em `js/game.js` foi atualizada para passar o objeto `config`.

Isso alinha o design de `updateEnemies` com o de `spawnEnemy`, tornando o módulo `enemy` mais limpo e menos propenso a erros semelhantes no futuro.