### PR TITLE
chore: Desabilita o som por padrão

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -185,7 +185,7 @@ export const config = {
     xp: 0,
     level: 1,
     skillPoints: 0,
-    soundEnabled: true,
+    soundEnabled: false,
     gamePaused: false,
     particlesAbsorbed: 0,
     enemiesDestroyed: 0,


### PR DESCRIPTION
Desabilita o som por padrão para contornar problemas de ambiente (erros 416 ao carregar áudio no Codespaces) que estão impedindo os testes de jogabilidade.

Isso permite que o jogo seja executado e testado sem ser interrompido por erros de áudio que não podem ser resolvidos diretamente no código da aplicação.